### PR TITLE
Cleaned up property definitions

### DIFF
--- a/Classes/BadgeStyle.h
+++ b/Classes/BadgeStyle.h
@@ -53,13 +53,13 @@ typedef enum : NSUInteger {
 
 }
 
-@property(nonatomic) UIColor *badgeTextColor;
-@property(nonatomic) UIColor *badgeInsetColor;
-@property(nonatomic) UIColor *badgeFrameColor;
+@property(nonatomic, strong) UIColor *badgeTextColor;
+@property(nonatomic, strong) UIColor *badgeInsetColor;
+@property(nonatomic, strong) UIColor *badgeFrameColor;
 @property(nonatomic) BadgeStyleFontType badgeFontType;
-@property(nonatomic,readwrite) BOOL badgeFrame;
-@property(nonatomic,readwrite) BOOL badgeShining;
-@property(nonatomic,readwrite) BOOL badgeShadow;
+@property(nonatomic) BOOL badgeFrame;
+@property(nonatomic) BOOL badgeShining;
+@property(nonatomic) BOOL badgeShadow;
 
 
 + (BadgeStyle*) defaultStyle;

--- a/Classes/CustomBadge.h
+++ b/Classes/CustomBadge.h
@@ -44,10 +44,10 @@
     BadgeStyle *badgeStyle;
 }
 
-@property(nonatomic) NSString *badgeText;
-@property(nonatomic) BadgeStyle *badgeStyle;
-@property(nonatomic,readwrite) CGFloat badgeCornerRoundness;
-@property(nonatomic,readwrite) CGFloat badgeScaleFactor;
+@property(nonatomic, strong) NSString *badgeText;
+@property(nonatomic, strong) BadgeStyle *badgeStyle;
+@property(nonatomic) CGFloat badgeCornerRoundness;
+@property(nonatomic) CGFloat badgeScaleFactor;
 
 + (CustomBadge*) customBadgeWithString:(NSString *)badgeString;
 + (CustomBadge*) customBadgeWithString:(NSString *)badgeString withScale:(CGFloat)scale;


### PR DESCRIPTION
Lack of property attribute assumes 'assign' in a mixed ARC/non-ARC project and throws a bunch of warnings. Explicitly set relevant properties to 'strong'. Also removed unnecessary readwrite attributes. 
