### PR TITLE
Border/Frame: Ensure that the frame scales if the scale is < 1

### DIFF
--- a/Classes/CustomBadge.m
+++ b/Classes/CustomBadge.m
@@ -204,7 +204,10 @@
 	CGFloat lineSize = 2;
 	if(self.badgeScaleFactor>1) {
 		lineSize += self.badgeScaleFactor*0.25;
+	} else if (self.badgeScaleFactor >= 0 && self.badgeScaleFactor < 1) {
+		lineSize *= self.badgeScaleFactor;
 	}
+
 	CGContextSetLineWidth(context, lineSize);
 	CGContextSetStrokeColorWithColor(context, [self.badgeStyle.badgeFrameColor CGColor]);
 	CGContextAddArc(context, maxX-radius, minY+radius, radius, M_PI+(M_PI/2), 0, 0);


### PR DESCRIPTION
ATM the lineSize of the badge frame stays the same.

With this pull request the lineSize will scale from 1 to 0 accordingly to it's initial size. For example, if the scale is `0.5` the lineSize will be `1` since it's initial size is `2`.
